### PR TITLE
Fixed the line: 29 - Invoice reference code if already exists. In the inline Payment API documentation

### DIFF
--- a/accept-payment/inline-payment.md
+++ b/accept-payment/inline-payment.md
@@ -26,7 +26,7 @@ Inline Payment
 
 {% api-method-body-parameters %}
 {% api-method-parameter name="key " type="string" required=true %}
-Invoice refrence code if already exists
+API PUBLIC KEY
 {% endapi-method-parameter %}
 
 {% api-method-parameter name="reference\_code" type="string" required=true %}


### PR DESCRIPTION
Change the description of key:   Invoice reference code if already exists -> API PUBLIC KEY